### PR TITLE
Percent-encoding of non-ASCII strings

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -6,7 +6,7 @@ const app = express()
 app.use(cors())
 
 app.get('/', (req, res) => {
-  const url = 'https://' + req.query.url
+  const url = 'https://' + encodeURI(req.query.url)
   createTOC(url)
   .then(results => {
     res.send({


### PR DESCRIPTION
I added encodeURI because I would like to use it even if the article contains a non-ASCII string.